### PR TITLE
Add optional sidebar and breadcrumb

### DIFF
--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -167,7 +167,9 @@ class Application extends Component {
 				<div className="app">
 					<Header hasSidebar={this.props.hasSidebar} app={this}/>
 					<div className="app-body">
-						<Sidebar hasSidebar={this.props.hasSidebar} app={this} navigation={this.Navigation}/>
+						{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
+							<Sidebar app={this} navigation={this.Navigation} display="lg"/> : 
+							<Sidebar app={this} navigation={this.Navigation} display="xs"/>}
 						<main className="main">
 							{(this.props.hasBreadcrumb || typeof this.props.hasBreadcrumb === 'undefined') ? 
 								<AppBreadcrumb appRoutes={this.Router.Routes} router={router}/> : null}

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -124,11 +124,12 @@ class Application extends Component {
 		else return (
 			<Provider store={this.Store}>
 				<div className="app">
-					<Header app={this}/>
+					<Header hasSidebar={this.props.hasSidebar} app={this}/>
 					<div className="app-body">
 						<Sidebar hasSidebar={this.props.hasSidebar} app={this} navigation={this.Navigation}/>
 						<main className="main">
-							{this.props.hasBreadcrumb ? <AppBreadcrumb appRoutes={this.Router.Routes} router={router}/> : null}
+							{(this.props.hasBreadcrumb || typeof this.props.hasBreadcrumb === 'undefined') ? 
+								<AppBreadcrumb appRoutes={this.Router.Routes} router={router}/> : null}
 							<Container fluid>
 								<Switch>
 									{this.Router.Routes.map((route, idx) => {

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -45,6 +45,25 @@ class Application extends Component {
 	), document.getElementById('app'));
 
 ...
+
+	Example of settings in Module of the Application
+	Following above settings, this will show the item in
+	the header and when the screen is diminished (e.g. screening
+	using the mobile phone), the item is moved to the sidebar and
+	it is accessible by the sidebar toggler button.
+
+...
+
+	    app.Navigation.addItem({
+            name: 'Item 1',
+            url: '',
+        });
+
+
+        const headerService = app.locateService("HeaderService");
+        headerService.addComponent(NavLink,{children: "Item 1", href: "", style: {marginRight: "2rem"}});
+
+...
 	*/
 
 	constructor(props){

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -126,9 +126,9 @@ class Application extends Component {
 				<div className="app">
 					<Header app={this}/>
 					<div className="app-body">
-						<Sidebar app={this} navigation={this.Navigation}/>
+						<Sidebar hasSidebar={this.props.hasSidebar} app={this} navigation={this.Navigation}/>
 						<main className="main">
-							<AppBreadcrumb appRoutes={this.Router.Routes} router={router}/>
+							{this.props.hasBreadcrumb ? <AppBreadcrumb appRoutes={this.Router.Routes} router={router}/> : null}
 							<Container fluid>
 								<Switch>
 									{this.Router.Routes.map((route, idx) => {

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -25,6 +25,28 @@ import ReduxService from '../services/ReduxService';
 
 class Application extends Component {
 
+	/*
+	Example of use hasSidebar and hasBreadcrumb.
+	It must be set in Application.
+	If not set, it is considered as true.
+
+...
+
+	const config = {
+		hasSidebar: false,
+		hasBreadcrumb: false
+	}
+
+
+	ReactDOM.render((
+		<BrowserRouter>
+			<Application modules={modules} {...config}/>
+		</BrowserRouter>
+	), document.getElementById('app'));
+
+...
+	*/
+
 	constructor(props){
 		super(props);
 

--- a/src/containers/Application.js
+++ b/src/containers/Application.js
@@ -165,7 +165,7 @@ class Application extends Component {
 		else return (
 			<Provider store={this.Store}>
 				<div className="app">
-					<Header hasSidebar={this.props.hasSidebar} app={this}/>
+					<Header app={this}/>
 					<div className="app-body">
 						{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
 							<Sidebar app={this} navigation={this.Navigation} display="lg"/> : 

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -23,7 +23,8 @@ class Header extends Component {
 		return (<React.Fragment>
 			<AppHeader fixed>
 				
-				<AppSidebarToggler className="d-lg-none" display="md" mobile />
+				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
+					<AppSidebarToggler className="d-lg-none" display="md" mobile />  : null}
 				<AppNavbarBrand full={this.HeaderService.BrandImageFull} minimized={this.HeaderService.BrandImageMinimized} />
 				<AppSidebarToggler className="d-md-down-none" display="lg" />
 

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -23,19 +23,16 @@ class Header extends Component {
 	render() {
 		return (<React.Fragment>
 			<AppHeader fixed>
-			
 				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
 					<AppSidebarToggler className="d-lg-none" display="md" mobile />
 				: this.HeaderService.Items.length > 0 ?
 					<AppSidebarToggler className="d-lg-none" display="md" mobile />
 				: null
 				}
-
 				<AppNavbarBrand full={this.HeaderService.BrandImageFull} minimized={this.HeaderService.BrandImageMinimized} />
 				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
 					<AppSidebarToggler className="d-md-down-none" display="lg" />
 				: null}
-
 				{this.HeaderService.Items.length > 0 ?
 					<Nav className="d-md d-md-down-none" display="lg" navbar>
 						{this.HeaderService.Items.map((item, idx) => (
@@ -45,7 +42,6 @@ class Header extends Component {
 						))}
 					</Nav>
 				: null}
-
 			</AppHeader>
 		</React.Fragment>);
 	}

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -23,14 +23,14 @@ class Header extends Component {
 	render() {
 		return (<React.Fragment>
 			<AppHeader fixed>
-				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
+				{(this.App.props.hasSidebar || typeof this.App.props.hasSidebar === 'undefined') ? 
 					<AppSidebarToggler className="d-lg-none" display="md" mobile />
 				: this.HeaderService.Items.length > 0 ?
 					<AppSidebarToggler className="d-lg-none" display="md" mobile />
 				: null
 				}
 				<AppNavbarBrand full={this.HeaderService.BrandImageFull} minimized={this.HeaderService.BrandImageMinimized} />
-				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
+				{(this.App.props.hasSidebar || typeof this.App.props.hasSidebar === 'undefined') ? 
 					<AppSidebarToggler className="d-md-down-none" display="lg" />
 				: null}
 				{this.HeaderService.Items.length > 0 ?

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -23,20 +23,28 @@ class Header extends Component {
 	render() {
 		return (<React.Fragment>
 			<AppHeader fixed>
+			
+				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
+					<AppSidebarToggler className="d-lg-none" display="md" mobile />
+				: this.HeaderService.Items.length > 0 ?
+					<AppSidebarToggler className="d-lg-none" display="md" mobile />
+				: null
+				}
 
-				<AppSidebarToggler className="d-lg-none" display="md" mobile />
 				<AppNavbarBrand full={this.HeaderService.BrandImageFull} minimized={this.HeaderService.BrandImageMinimized} />
 				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
 					<AppSidebarToggler className="d-md-down-none" display="lg" />
 				: null}
 
-				<Nav className="d-md d-md-down-none" display="lg" navbar>
-					{this.HeaderService.Items.map((item, idx) => (
-						<NavItem key={idx}>
-							<item.component key={idx} {...item.componentProps} app={this.App}/>
-						</NavItem>
-					))}
-				</Nav>
+				{this.HeaderService.Items.length > 0 ?
+					<Nav className="d-md d-md-down-none" display="lg" navbar>
+						{this.HeaderService.Items.map((item, idx) => (
+							<NavItem key={idx}>
+								<item.component key={idx} {...item.componentProps} app={this.App}/>
+							</NavItem>
+						))}
+					</Nav>
+				: null}
 
 			</AppHeader>
 		</React.Fragment>);

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -7,7 +7,8 @@ import {
 } from '@coreui/react';
 
 import {
-	Nav
+	Nav,
+	NavItem
 } from 'reactstrap';
 
 class Header extends Component {
@@ -22,27 +23,21 @@ class Header extends Component {
 	render() {
 		return (<React.Fragment>
 			<AppHeader fixed>
-				<Navbar className="nav-fill w-100 h-100" color="light" expand="md">
 
-					<AppNavbarBrand full={this.HeaderService.BrandImageFull} minimized={this.HeaderService.BrandImageMinimized} />
-					{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
-						<React.Fragment>
-							<AppSidebarToggler className="d-lg-none" display="md" mobile />
-							<AppSidebarToggler className="d-md-down-none" display="lg" />
-						</React.Fragment>  
-					: null}
+				<AppSidebarToggler className="d-lg-none" display="md" mobile />
+				<AppNavbarBrand full={this.HeaderService.BrandImageFull} minimized={this.HeaderService.BrandImageMinimized} />
+				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
+					<AppSidebarToggler className="d-md-down-none" display="lg" />
+				: null}
 
-					{(this.HeaderService.Items.length > 0) ? <NavbarToggler onClick={this.toggle} id="toggler"/> : null}
-					<Collapse isOpen={this.state.isOpen} navbar expand="md">
-						<Nav className="ml-auto" navbar>
-							{this.HeaderService.Items.map((item, idx) => (
-								<NavItem key={idx}>
-									<item.component key={idx} {...item.componentProps} app={this.App}/>
-								</NavItem>
-							))}
-						</Nav>
-					</Collapse>
-				</Navbar>
+				<Nav className="d-md d-md-down-none" display="lg" navbar>
+					{this.HeaderService.Items.map((item, idx) => (
+						<NavItem key={idx}>
+							<item.component key={idx} {...item.componentProps} app={this.App}/>
+						</NavItem>
+					))}
+				</Nav>
+
 			</AppHeader>
 		</React.Fragment>);
 	}

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -22,18 +22,27 @@ class Header extends Component {
 	render() {
 		return (<React.Fragment>
 			<AppHeader fixed>
-				
-				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
-					<AppSidebarToggler className="d-lg-none" display="md" mobile />  : null}
-				<AppNavbarBrand full={this.HeaderService.BrandImageFull} minimized={this.HeaderService.BrandImageMinimized} />
-				<AppSidebarToggler className="d-md-down-none" display="lg" />
+				<Navbar className="nav-fill w-100 h-100" color="light" expand="md">
 
-				<Nav className="ml-auto" navbar>
-					{this.HeaderService.Items.map((item, idx) => (
-						<item.component key={idx} {...item.componentProps} app={this.App}/>
-					))}
-				</Nav>
+					<AppNavbarBrand full={this.HeaderService.BrandImageFull} minimized={this.HeaderService.BrandImageMinimized} />
+					{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
+						<React.Fragment>
+							<AppSidebarToggler className="d-lg-none" display="md" mobile />
+							<AppSidebarToggler className="d-md-down-none" display="lg" />
+						</React.Fragment>  
+					: null}
 
+					{(this.HeaderService.Items.length > 0) ? <NavbarToggler onClick={this.toggle} id="toggler"/> : null}
+					<Collapse isOpen={this.state.isOpen} navbar expand="md">
+						<Nav className="ml-auto" navbar>
+							{this.HeaderService.Items.map((item, idx) => (
+								<NavItem key={idx}>
+									<item.component key={idx} {...item.componentProps} app={this.App}/>
+								</NavItem>
+							))}
+						</Nav>
+					</Collapse>
+				</Navbar>
 			</AppHeader>
 		</React.Fragment>);
 	}

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -24,27 +24,16 @@ class Sidebar extends Component {
 	render() {
 		return (
 			<React.Fragment>
-				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
-					<AppSidebar fixed display="lg">
-						<AppSidebarHeader />
-						<AppSidebarForm />
-						<AppSidebarNav
-							navConfig={this.Navigation.getItems()}
-							router={router}
-						/>
-						<AppSidebarFooter />
-						<AppSidebarMinimizer />
-					</AppSidebar> : 
-					<AppSidebar fixed display="xs">
-						<AppSidebarHeader />
-						<AppSidebarForm />
-						<AppSidebarNav
-							navConfig={this.Navigation.getItems()}
-							router={router}
-						/>
-						<AppSidebarFooter />
-						<AppSidebarMinimizer />
-					</AppSidebar>}
+				<AppSidebar fixed display={this.props.display}>
+					<AppSidebarHeader />
+					<AppSidebarForm />
+					<AppSidebarNav
+						navConfig={this.Navigation.getItems()}
+						router={router}
+					/>
+					<AppSidebarFooter />
+					<AppSidebarMinimizer />
+				</AppSidebar>
 			</React.Fragment>
 		);
 	}

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -22,7 +22,8 @@ class Sidebar extends Component {
 	}
 
 	render() {
-		return (<React.Fragment>
+		return (
+			<React.Fragment>
 				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
 					<AppSidebar fixed display="lg">
 						<AppSidebarHeader />
@@ -33,7 +34,7 @@ class Sidebar extends Component {
 						/>
 						<AppSidebarFooter />
 						<AppSidebarMinimizer />
-					</AppSidebar>  : 
+					</AppSidebar> : 
 					<AppSidebar fixed display="xs">
 						<AppSidebarHeader />
 						<AppSidebarForm />
@@ -44,7 +45,8 @@ class Sidebar extends Component {
 						<AppSidebarFooter />
 						<AppSidebarMinimizer />
 					</AppSidebar>}
-		</React.Fragment>);
+			</React.Fragment>
+		);
 	}
 
 }

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -23,7 +23,7 @@ class Sidebar extends Component {
 
 	render() {
 		return (<React.Fragment>
-			{this.props.hasSidebar ? 
+			{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
 				<AppSidebar fixed display="lg">
 					<AppSidebarHeader />
 					<AppSidebarForm />
@@ -33,8 +33,8 @@ class Sidebar extends Component {
 					/>
 					<AppSidebarFooter />
 					<AppSidebarMinimizer />
-				</AppSidebar> : 
-			null}
+				</AppSidebar>
+			: null}
 		</React.Fragment>);
 	}
 

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -23,18 +23,27 @@ class Sidebar extends Component {
 
 	render() {
 		return (<React.Fragment>
-			{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
-				<AppSidebar fixed display="lg">
-					<AppSidebarHeader />
-					<AppSidebarForm />
-					<AppSidebarNav
-						navConfig={this.Navigation.getItems()}
-						router={router}
-					/>
-					<AppSidebarFooter />
-					<AppSidebarMinimizer />
-				</AppSidebar>
-			: null}
+				{(this.props.hasSidebar || typeof this.props.hasSidebar === 'undefined') ? 
+					<AppSidebar fixed display="lg">
+						<AppSidebarHeader />
+						<AppSidebarForm />
+						<AppSidebarNav
+							navConfig={this.Navigation.getItems()}
+							router={router}
+						/>
+						<AppSidebarFooter />
+						<AppSidebarMinimizer />
+					</AppSidebar>  : 
+					<AppSidebar fixed display="xs">
+						<AppSidebarHeader />
+						<AppSidebarForm />
+						<AppSidebarNav
+							navConfig={this.Navigation.getItems()}
+							router={router}
+						/>
+						<AppSidebarFooter />
+						<AppSidebarMinimizer />
+					</AppSidebar>}
 		</React.Fragment>);
 	}
 

--- a/src/containers/Sidebar.js
+++ b/src/containers/Sidebar.js
@@ -23,16 +23,18 @@ class Sidebar extends Component {
 
 	render() {
 		return (<React.Fragment>
-			<AppSidebar fixed display="lg">
-				<AppSidebarHeader />
-				<AppSidebarForm />
-				<AppSidebarNav
-					navConfig={this.Navigation.getItems()}
-					router={router}
-				/>
-				<AppSidebarFooter />
-				<AppSidebarMinimizer />
-			</AppSidebar>
+			{this.props.hasSidebar ? 
+				<AppSidebar fixed display="lg">
+					<AppSidebarHeader />
+					<AppSidebarForm />
+					<AppSidebarNav
+						navConfig={this.Navigation.getItems()}
+						router={router}
+					/>
+					<AppSidebarFooter />
+					<AppSidebarMinimizer />
+				</AppSidebar> : 
+			null}
 		</React.Fragment>);
 	}
 


### PR DESCRIPTION
This pull request allows to disable sidebar and breadcrumb. It also remove items added to header, when the screen is diminished (e.g. in mobile phones). Those header items then appear in the sidebar, if added previously to the Navigation. Example of settings is written in the description of Application.js